### PR TITLE
Streamlining the installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,3 @@ The basic environment including the basic required dependencies can be created u
 the provided specification:
 
     conda env create -f environment.yml
-
-After the environment has been activated, the external FORTRAN library FISHPACK needs to be
-installed. This is accomplished by the following steps:
-
-    1. Change directory to the CIDER root directory
-    2. cd external
-    3. wget https://github.com/NCAR/NCAR-Classic-Libraries-for-Geophysics/raw/main/FishPack/fishpack4.1.tar.gz
-    4. tar -xvzf fishpack4.1.tar.gz
-    5. cd ../cider/solvers/fishpack
-    6. make
-
-If the compilation fails, the makefile (cider/solvers/fishpack/makefile) most likely will be needed to be tailored
-for your system.
-
-Finally, the package [pysmsh](https://github.com/jpomoell/pysmsh) is required to be installed.
-Installing it requires only cloning the repo and making it visible to the CIDER environment.

--- a/cider/solvers/tridiagonal.py
+++ b/cider/solvers/tridiagonal.py
@@ -10,7 +10,7 @@
 
 import numpy as np
 
-import cider.solvers.fishpack.blktri as blktri
+from fishpack import blktri
 
 
 class BlockTridiagonalSolver:

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/pricedj/fishpack
+    - git+https://github.com/jpomoell/pysmsh

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.9
+  - python=3.10
   - numba>=0.55
-  - numpy  
+  - numpy=2.0.2
   - scipy
   - matplotlib
   - multimethod
@@ -13,4 +13,7 @@ dependencies:
   - sunpy>=5.1
   - astropy
   - pyevtk
-  
+  - gfortran
+  - pip
+  - pip:
+    - git+https://github.com/pricedj/fishpack


### PR DESCRIPTION
1. Switches from the manual fortran step to pip installing a fishpack repo made for this instead.
2. Switches from the manual pysmsh step to pip installing the repo instead.