### PR TITLE
Setting default kernel

### DIFF
--- a/notebooks/Basic PFSS example.ipynb
+++ b/notebooks/Basic PFSS example.ipynb
@@ -330,9 +330,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cider",
+   "display_name": "CIDER",
    "language": "python",
-   "name": "python3"
+   "name": "cider"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/Field line tracing example.ipynb
+++ b/notebooks/Field line tracing example.ipynb
@@ -604,9 +604,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cider",
+   "display_name": "CIDER",
    "language": "python",
-   "name": "python3"
+   "name": "cider"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/Magnetofrictional example.ipynb
+++ b/notebooks/Magnetofrictional example.ipynb
@@ -523,9 +523,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cider",
+   "display_name": "CIDER",
    "language": "python",
-   "name": "python3"
+   "name": "cider"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
To facilitate one-click functionality from https://soler-horizon.eu/hub/, and to match the default name from the install instructions.